### PR TITLE
Move rimraf to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,90 +1,90 @@
 {
-    "name": "vscode-elm-test-runner",
-    "displayName": "Run Elm tests",
-    "description": "Run Elm tests in VS Code",
-    "icon": "resources/elmIcon.png",
-    "repository": {
-        "type": "git",
-        "url": " https://github.com/frawa/vscode-elm-test-runner.git"
-    },
-    "version": "0.9.8",
-    "publisher": "FraWa",
-    "categories": [
-        "Programming Languages"
-    ],
-    "license": "MIT",
-    "activationEvents": [
-        "workspaceContains:**/elm.json"
-    ],
-    "main": "./out/extension",
-    "extensionDependencies": [
-        "hbenl.vscode-test-explorer"
-    ],
-    "contributes": {
-        "configuration": {
-            "type": "object",
-            "title": "Elm Test Runner",
-            "properties": {
-                "elmTestRunner.logpanel": {
-                    "description": "write diagnotic logs to an output panel",
-                    "type": "boolean",
-                    "scope": "resource"
-                },
-                "elmTestRunner.showElmTestOutput": {
-                    "description": "show output of elm-test as Terminal Task",
-                    "type": "boolean",
-                    "scope": "resource"
-                }
-            }
+  "name": "vscode-elm-test-runner",
+  "displayName": "Run Elm tests",
+  "description": "Run Elm tests in VS Code",
+  "icon": "resources/elmIcon.png",
+  "repository": {
+    "type": "git",
+    "url": " https://github.com/frawa/vscode-elm-test-runner.git"
+  },
+  "version": "0.9.8",
+  "publisher": "FraWa",
+  "categories": [
+    "Programming Languages"
+  ],
+  "license": "MIT",
+  "activationEvents": [
+    "workspaceContains:**/elm.json"
+  ],
+  "main": "./out/extension",
+  "extensionDependencies": [
+    "hbenl.vscode-test-explorer"
+  ],
+  "contributes": {
+    "configuration": {
+      "type": "object",
+      "title": "Elm Test Runner",
+      "properties": {
+        "elmTestRunner.logpanel": {
+          "description": "write diagnotic logs to an output panel",
+          "type": "boolean",
+          "scope": "resource"
         },
-        "taskDefinitions": [
-            {
-                "type": "elm-test",
-                "properties": {}
-            }
-        ]
+        "elmTestRunner.showElmTestOutput": {
+          "description": "show output of elm-test as Terminal Task",
+          "type": "boolean",
+          "scope": "resource"
+        }
+      }
     },
-    "scripts": {
-        "clean": "rimraf out *.vsix",
-        "build": "tsc",
-        "watch": "tsc -watch",
-        "lint": "tslint -p .",
-        "lint-fix": "tslint --fix -p .",
-        "test": "mocha",
-        "test-watch": "mocha --watch",
-        "test-mutate": "stryker run",
-        "vscode:prepublish": "yarn clean && yarn build && yarn test",
-        "vsce-package": "vsce package --yarn",
-        "vsce-publish": "vsce publish --yarn"
-    },
-    "mocha": {
-        "require": "ts-node/register",
-        "spec": "src/test/**/*.test.ts"
-    },
-    "devDependencies": {
-        "@stryker-mutator/core": "^4.0.0-beta.3",
-        "@stryker-mutator/mocha-framework": "^4.0.0-beta.3",
-        "@stryker-mutator/mocha-runner": "^4.0.0-beta.3",
-        "@stryker-mutator/typescript": "^4.0.0-beta.3",
-        "@types/chai": "^4.2.12",
-        "@types/mocha": "^8.0.3",
-        "@types/node": "^14.6.0",
-        "@types/vscode": "^1.48.0",
-        "chai": "^4.2.0",
-        "mocha": "^8.1.2",
-        "stryker-cli": "^1.0.0",
-        "ts-mocha": "^7.0.0",
-        "tslint": "^6.1.3",
-        "typescript": "^4.0.2",
-        "vsce": "^1.79.5"
-    },
-    "engines": {
-        "vscode": "^1.48.0"
-    },
-    "dependencies": {
-        "jsonc-parser": "^2.3.0",
-        "rimraf": "^3.0.2",
-        "vscode-test-adapter-api": "^1.7.0",
-        "vscode-test-adapter-util": "^0.7.1"
-    }
+    "taskDefinitions": [
+      {
+        "type": "elm-test",
+        "properties": {}
+      }
+    ]
+  },
+  "scripts": {
+    "clean": "rimraf out *.vsix",
+    "build": "tsc",
+    "watch": "tsc -watch",
+    "lint": "tslint -p .",
+    "lint-fix": "tslint --fix -p .",
+    "test": "mocha",
+    "test-watch": "mocha --watch",
+    "test-mutate": "stryker run",
+    "vscode:prepublish": "yarn clean && yarn build && yarn test",
+    "vsce-package": "vsce package --yarn",
+    "vsce-publish": "vsce publish --yarn"
+  },
+  "mocha": {
+    "require": "ts-node/register",
+    "spec": "src/test/**/*.test.ts"
+  },
+  "devDependencies": {
+    "@stryker-mutator/core": "^4.0.0-beta.3",
+    "@stryker-mutator/mocha-framework": "^4.0.0-beta.3",
+    "@stryker-mutator/mocha-runner": "^4.0.0-beta.3",
+    "@stryker-mutator/typescript": "^4.0.0-beta.3",
+    "@types/chai": "^4.2.12",
+    "@types/mocha": "^8.0.3",
+    "@types/node": "^14.6.0",
+    "@types/vscode": "^1.48.0",
+    "chai": "^4.2.0",
+    "mocha": "^8.1.2",
+    "rimraf": "^3.0.2",
+    "stryker-cli": "^1.0.0",
+    "ts-mocha": "^7.0.0",
+    "tslint": "^6.1.3",
+    "typescript": "^4.0.2",
+    "vsce": "^1.79.5"
+  },
+  "engines": {
+    "vscode": "^1.48.0"
+  },
+  "dependencies": {
+    "jsonc-parser": "^2.3.0",
+    "vscode-test-adapter-api": "^1.7.0",
+    "vscode-test-adapter-util": "^0.7.1"
+  }
 }


### PR DESCRIPTION
I think this was wrong?

Haven't used yarn much, so not sure if the lockfile is really up to date. I did run `yarn`